### PR TITLE
rewrite bucket, use a struct instead of map

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -73,6 +73,7 @@ func (b *Breaker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_, _, _, _, ratio := timeline.QueryStatus(url)
+	log.Printf("ratio: %f", ratio)
 	if ratio > 0.3 {
 		log.Printf("too many requests, ratio is %f", ratio)
 		w.WriteHeader(http.StatusTooManyRequests)


### PR DESCRIPTION
here is the benchmark before and after rewrite:

```bash
$ # before rewrite
BenchmarkWRRSelect-4          	50000000	        26.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkRouterGenericURL-4   	10000000	       194 ns/op	      48 B/op	       2 allocs/op
BenchmarkIncr-4               	 5000000	       400 ns/op	      35 B/op	       2 allocs/op
BenchmarkQueryStatus-4        	 2000000	       684 ns/op	     140 B/op	       8 allocs/op
$ # after rewrite
BenchmarkWRRSelect-4          	50000000	        26.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkRouterGenericURL-4   	10000000	       194 ns/op	      48 B/op	       2 allocs/op
BenchmarkIncr-4               	10000000	       169 ns/op	       0 B/op	       0 allocs/op
BenchmarkQueryStatus-4        	50000000	        30.9 ns/op	       0 B/op	       0 allocs/op
```