### PR TITLE
benchmark for ServeHTTP & Proxy

### DIFF
--- a/breaker.go
+++ b/breaker.go
@@ -73,7 +73,6 @@ func (b *Breaker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_, _, _, _, ratio := timeline.QueryStatus(url)
-	log.Printf("ratio: %f", ratio)
 	if ratio > 0.3 {
 		log.Printf("too many requests, ratio is %f", ratio)
 		w.WriteHeader(http.StatusTooManyRequests)
@@ -90,5 +89,4 @@ func (b *Breaker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// record the response
 	timeline.Incr(url, responseWriter.Status())
-	log.Printf("request returned with status code %d", responseWriter.Status())
 }

--- a/breaker_test.go
+++ b/breaker_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -177,4 +179,52 @@ func TestTSR(t *testing.T) {
 	req.Host = app
 	w = httptest.NewRecorder()
 	b.ServeHTTP(w, req)
+}
+
+// it's declared in proxy.go, here is just for hint
+//// borrowed from Go:
+//// https://github.com/golang/go/blob/64ccd4589e657a380836d87e8dd801bf53c0d475/src/net/http/httputil/reverseproxy_test.go#L675-L681
+//type staticTransport struct {
+//res *http.Response
+//}
+
+//func (s *staticTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+//return s.res, nil
+//}
+
+//type fakeBalancer struct{}
+
+//var fakeBackend = Backend{"127.0.0.1", 9090, 1}
+
+//func (b fakeBalancer) Select() (*Backend, bool) {
+//return &fakeBackend, true
+//}
+
+func BenchmarkServeHTTP(b *testing.B) {
+	// replace the global variable transport in proxy.go
+	var app = "www.example.com"
+	res := &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}
+	transport = &staticTransport{res}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Host = app
+	r.URL.Path = "/src/this"
+
+	var upstreamConfig = APP{
+		app,
+		[]string{"/hello", "/src/:world", "/file/*sys"},
+		[]string{"GET", "POST", "POST"},
+		[]Backend{fakeBackend},
+	}
+
+	// make sure app, router, timeline, balancer exist
+	overrideAPP(breaker, upstreamConfig)
+
+	for i := 0; i < b.N; i++ {
+		breaker.ServeHTTP(w, r)
+	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	transport = &http.Transport{
+	transport http.RoundTripper = &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -28,7 +28,7 @@ var (
 )
 
 // Proxy use httputil.ReverseProxy
-func Proxy(balancer Balancer, w ResponseWriter, r *http.Request) {
+func Proxy(balancer Balancer, w http.ResponseWriter, r *http.Request) {
 	backend, found := balancer.Select()
 	if !found {
 		w.WriteHeader(http.StatusForbidden)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,8 +1,47 @@
 package main
 
 import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 func TestProxy(t *testing.T) {
+}
+
+// borrowed from Go:
+// https://github.com/golang/go/blob/64ccd4589e657a380836d87e8dd801bf53c0d475/src/net/http/httputil/reverseproxy_test.go#L675-L681
+type staticTransport struct {
+	res *http.Response
+}
+
+func (s *staticTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return s.res, nil
+}
+
+type fakeBalancer struct{}
+
+var fakeBackend = Backend{"127.0.0.1", 10089, 1}
+
+func (b fakeBalancer) Select() (*Backend, bool) {
+	return &fakeBackend, true
+}
+
+func BenchmarkProxy(b *testing.B) {
+	// replace the global variable transport in proxy.go
+	res := &http.Response{
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+	}
+	transport = &staticTransport{res}
+	balancer := fakeBalancer{}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+
+	for i := 0; i < b.N; i++ {
+		Proxy(balancer, w, r)
+	}
 }


### PR DESCRIPTION
proxy from `net.http` is really the bottleneck. maybe we should try to optimize it.

```
BenchmarkWRRSelect-4          	50000000	        21.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkServeHTTP-4          	  200000	      6381 ns/op	   33712 B/op	      14 allocs/op
BenchmarkProxy-4              	  200000	      5870 ns/op	   33664 B/op	      12 allocs/op
BenchmarkRouterGenericURL-4   	10000000	       122 ns/op	      48 B/op	       2 allocs/op
BenchmarkIncr-4               	10000000	       135 ns/op	       0 B/op	       0 allocs/op
BenchmarkQueryStatus-4        	100000000	        22.3 ns/op	       0 B/op	       0 allocs/op
```